### PR TITLE
Fix #21 bulmaActionButton works only on 2nd click

### DIFF
--- a/inst/js-0.7.2/bulma-button-js.js
+++ b/inst/js-0.7.2/bulma-button-js.js
@@ -1,9 +1,9 @@
-
+/*
 $(document).on("click", "button.shinyBulmaActionButton", function(evt) {
     var el = $(evt.target);
     el.val(parseInt(el.val()) + 1);
     el.trigger("change");
-});
+});*/
 
 var shinyBulmaActionButton = new Shiny.InputBinding();
 $.extend(shinyBulmaActionButton, {
@@ -11,7 +11,7 @@ $.extend(shinyBulmaActionButton, {
     return $(scope).find(".shinyBulmaActionButton");
   },
   getValue: function(el) {
-    return parseInt($(el).val());
+    return $(el).data('val') || 0;
   },
   subscribe: function(el, callback) {
     $(el).on("click.shinyBulmaActionButton", function(e) {


### PR DESCRIPTION
Due to an incosistent usage of `data('val')` and `val()` the button
fires only after the second click. In order to fix this, we had to
harmonize the usage of the data slot and remove the duplicated event
handler to make sure that the value is changed only once.