### PR TITLE
Change interface of `bulmaTabs`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: Bulma for Shiny
 Version: 0.0.2.9000
 Authors@R: c(person("John", "Coene", email = "jcoenep@gmail.com", role = c("aut", "cre")),
   person("David", "Granjon", email = "david.granjon@uzh.ch", role = "aut", comment = "bulma-extensions"),
-  person("Thorn", "Thaler", email = "thorn.thaler@thothal.at", rolw = "aut"),
+  person("Thorn", "Thaler", email = "thorn.thaler@thothal.at", role = "aut"),
   person(family = "RinteRface", role = "cph")
   )
 Description: Bulma for Shiny. Contains also an implementation of some of the major components

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,6 +3,7 @@ Title: Bulma for Shiny
 Version: 0.0.2.9000
 Authors@R: c(person("John", "Coene", email = "jcoenep@gmail.com", role = c("aut", "cre")),
   person("David", "Granjon", email = "david.granjon@uzh.ch", role = "aut", comment = "bulma-extensions"),
+  person("Thorn", "Thaler", email = "thorn.thaler@thothal.at", rolw = "aut"),
   person(family = "RinteRface", role = "cph")
   )
 Description: Bulma for Shiny. Contains also an implementation of some of the major components

--- a/R/bulma-input.R
+++ b/R/bulma-input.R
@@ -538,6 +538,7 @@ bulmaSliderInput <- function(inputId, value, min, max, color = NULL, step = 1, c
     step = step,
     min = min,
     max = max,
+    value = value,
     style = "width: 100%;",
     orient = orient,
     ...

--- a/R/bulma-tabs.R
+++ b/R/bulma-tabs.R
@@ -55,7 +55,7 @@ bulmaTabs <- function(..., center = FALSE) {
   
   tabs <- lapply(seq_along(tabs), function(idx) {
     tab <- tabs[[idx]]
-    if (tagHasAttribute(tab, "id")) {
+    if (shiny::tagHasAttribute(tab, "id")) {
       warning("existing `id` attribute will be overwritten")
     }
     tab_id <- paste(tabset_id, idx, sep = "-")
@@ -65,12 +65,12 @@ bulmaTabs <- function(..., center = FALSE) {
   })
   
   links <- lapply(tabs, function(tab) {
-    if (!tagHasAttribute(tab, "data-label")) {
+    if (!shiny::tagHasAttribute(tab, "data-label")) {
       stop("tabs must contain an `data-label` attribute - ",
            "create tabs with `bulmaTab`")
     }
-    label <- tagGetAttribute(tab, "data-label")
-    tab_id <- tagGetAttribute(tab, "id")
+    label <- shiny::tagGetAttribute(tab, "data-label")
+    tab_id <- shiny::tagGetAttribute(tab, "id")
     shiny::tags$li(
       shiny::tags$a(
         href = paste0("#", tab_id),
@@ -79,12 +79,12 @@ bulmaTabs <- function(..., center = FALSE) {
     )
   })
   
-  tabs_header <- div(
+  tabs_header <- shiny::tags$div(
     shiny::tags$ul(links),
     class = "tabs")
   
   if (center) {
-    tabs_header <- tagAppendAttributes(
+    tabs_header <- shiny::tagAppendAttributes(
       tabs_header,
       class = "is-centered"
     )

--- a/inst/js-0.7.2/bulma-tabs-js.js
+++ b/inst/js-0.7.2/bulma-tabs-js.js
@@ -1,3 +1,7 @@
 $( function() {
   $( ".bulmaTabs" ).tabs();
+  $(".tabs li[role = 'tab']").on("click", function() {
+     var $content = $($(this).children("a").attr("href"));
+     $content.find(".shiny-bound-output").trigger("shown");
+  });
 } );

--- a/inst/js-0.7.2/bulma-tabs-js.js
+++ b/inst/js-0.7.2/bulma-tabs-js.js
@@ -1,7 +1,10 @@
 $( function() {
   $( ".bulmaTabs" ).tabs();
   $(".tabs li[role = 'tab']").on("click", function() {
-     var $content = $($(this).children("a").attr("href"));
+     var $this = $(this);
+     var $content = $($this.children("a").attr("href"));
      $content.find(".shiny-bound-output").trigger("shown");
+     $this.siblings().children("a").each((_, el) => 
+         $($(el).attr("href")).find(".shiny-bound-output").trigger("hidden"));
   });
 } );

--- a/man/tabs.Rd
+++ b/man/tabs.Rd
@@ -5,16 +5,14 @@
 \alias{bulmaTab}
 \title{Add tabs}
 \usage{
-bulmaTabs(tabs, center = FALSE, ...)
+bulmaTabs(..., center = FALSE)
 
 bulmaTab(label, ...)
 }
 \arguments{
-\item{tabs}{\code{bulmaTab} elements.}
+\item{...}{any element.}
 
 \item{center}{set to center.}
-
-\item{...}{any element.}
 
 \item{label}{label of tab.}
 }
@@ -29,7 +27,6 @@ shinyApp(
   ui = bulmaPage(
    bulmaTitle("Hello Bulma"),
    bulmaTabs(
-     tabs = c("Tab 1", "Tab 2", "Tab 3"),
      center = TRUE,
      bulmaTab(
        "Tab 1",


### PR DESCRIPTION
In the current implementation, the `id` tag for the content container is created from the `label`. This can lead to duplicated `id` elements:

```r
tabs <- bulmaTabs("tab 1", FALSE, bulmaTab("tab 1", p("placeholder")))

bulmaPage(tabs, tabs)
```

Secondly, the position of the `center` argument, makes it necessary that one specifies the `center` argument even if one does not want to change the default.

In this (**API breaking**) PR, I propose another interface for the 2  functions, which avoids duplication, assigns "unique" ids and make the usage easier.